### PR TITLE
Create config file from env variables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,17 @@ if [ -n "$(ls -A /var/www/new_version)" ]; then
 
 fi
 
+SAMPLE_CONFIG_FILE="/var/www/html/_includes/config.SAMPLE.inc.php"
+OUTPUT_CONFIG_FILE="/var/www/html/_includes/config.inc.php"
+
+# Read the sample config file and replace the placeholders with environment variables
+sed -e "s|/dm|${DOMAINMOD_WEB_ROOT}|g" \
+    -e "s|localhost|${DOMAINMOD_DATABASE_HOST}|g" \
+    -e "s|db_name|${DOMAINMOD_DATABASE}|g" \
+    -e "s|db_username|${DOMAINMOD_USER}|g" \
+    -e "s|dbPassword123|${DOMAINMOD_PASSWORD}|g" \
+    $SAMPLE_CONFIG_FILE > $OUTPUT_CONFIG_FILE
+
 chown -R domainmod:domainmod /var/www/html
 
 chmod 777 /var/www/html/temp


### PR DESCRIPTION
As per the issue in https://github.com/domainmod/domainmod/issues/166 , when running DomainMOD with Docker, the config file does not exist.

As the [Docker Instructions](https://hub.docker.com/r/domainmod/domainmod) only tell us that we should use environment variables to configure the service, there should be something in entrypoint.sh (or elsewhere) that creates the config file and adds the information from the environment variables.

This PR should help with that.